### PR TITLE
Adjust to add support for Elementor Pro widgets

### DIFF
--- a/elementor-widget-manager.php
+++ b/elementor-widget-manager.php
@@ -152,7 +152,7 @@ final class Elementor_Widget_Manager {
 
 		$this->includes();
 
-		add_action( 'elementor/widgets/widgets_registered', array( $this, 'unregister_widgets' ), 10 );
+		add_action( 'elementor/widgets/widgets_registered', array( $this, 'unregister_widgets' ), 200 );
 	}
 
 	/**


### PR DESCRIPTION
This is a great plugin that I was looking to use on some sites but it wasn't unregistering widgets from Elementor Pro. After some research, I followed what was listed in https://github.com/elementor/elementor/issues/7256#issuecomment-469004422 as to the number following the unregister action.

Testing locally, this worked to remove widgets registered with Elementor Pro and I wanted to contribute back since it's a small change that others could use, as noted in #2.